### PR TITLE
IssueController, DTO and Mapper: Add Issue service and REST APIs scoped to projects

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,53 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.bughive</groupId>
-	<artifactId>bughive</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>bughive</name>
-	<description>Multi-tenant task management backend</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.bughive</groupId>
+    <artifactId>bughive</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bughive</name>
+    <description>Multi-tenant task management backend</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -60,12 +69,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<artifactId>spring-boot-starter-validation-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/src/main/java/com/bughive/controller/IssueController.java
+++ b/backend/src/main/java/com/bughive/controller/IssueController.java
@@ -1,0 +1,58 @@
+package com.bughive.controller;
+
+import com.bughive.dto.IssueRequest;
+import com.bughive.dto.IssueResponse;
+import com.bughive.entity.Issue;
+import com.bughive.service.IssueService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class IssueController {
+    //        createIssue(Issue issue)
+    //        getIssuesByProject(Long projectId)
+    //        getIssueById(Long id)
+    //        Validate issue.project != null.
+    public final IssueService issueService;
+
+    @PostMapping("/issues")
+    public ResponseEntity<IssueResponse> creatIssue(@Valid @RequestBody IssueRequest issue){
+        // Adding the DTO for each and every entity. Entity exposes your database schema directly to the public.
+        // A hacker could send a JSON including restricted fields like id
+        IssueResponse savedIssue = issueService.createIssue(issue);
+
+        // 2. Dynamic Location Header generation and expand means replace the {id} -> value(12)
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                        .path("{/id}")
+                        .buildAndExpand(savedIssue.getId())
+                        .toUri();
+        // 3. Return 201 Created with Location header and Body
+        return  ResponseEntity.created(location).body(savedIssue);
+    }
+
+    @GetMapping("/issues/{id}")
+    public ResponseEntity<IssueResponse> getIssueById(@PathVariable Long id){
+        return issueService.getIssueById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    //**** IMP **** Change the Id of project to the {projectId}
+    @Transactional(readOnly = true)
+    @GetMapping("/projects/{projectId}/issues")
+    public ResponseEntity<List<IssueResponse>> getIssuesByProjectId(@PathVariable Long projectId){
+        @Nullable List<IssueResponse> issues =  issueService.getIssuesByProjectId(projectId);
+        return ResponseEntity.ok(issues);
+
+    }
+}

--- a/backend/src/main/java/com/bughive/dto/IssueRequest.java
+++ b/backend/src/main/java/com/bughive/dto/IssueRequest.java
@@ -1,0 +1,16 @@
+package com.bughive.dto;
+
+import com.bughive.entity.IssuePriority;
+import com.bughive.entity.IssueStatus;
+import lombok.Data;
+
+@Data
+public class IssueRequest {
+    private String title;
+    private String description;
+    private IssueStatus status;
+    private IssuePriority priority;
+    private Long projectId;
+    private Long assigneeId; // nullable
+
+}

--- a/backend/src/main/java/com/bughive/dto/IssueResponse.java
+++ b/backend/src/main/java/com/bughive/dto/IssueResponse.java
@@ -1,0 +1,23 @@
+package com.bughive.dto;
+
+import com.bughive.entity.IssuePriority;
+import com.bughive.entity.IssueStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class IssueResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private IssueStatus status;
+    private IssuePriority priority;
+
+    private Long projectId;
+    private String projectName;
+
+    private Long assigneeId;   // nullable
+
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/bughive/entity/Issue.java
+++ b/backend/src/main/java/com/bughive/entity/Issue.java
@@ -6,12 +6,13 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
-@Entity
-@Table(name= "issues")
 @Data
+@Entity
+@Table(name = "issues")
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString(exclude = {"project", "assignee"})
 public class Issue {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/bughive/mapper/IssuseMapper.java
+++ b/backend/src/main/java/com/bughive/mapper/IssuseMapper.java
@@ -1,0 +1,61 @@
+package com.bughive.mapper;
+
+import com.bughive.dto.IssueResponse;
+import com.bughive.entity.Issue;
+import org.springframework.stereotype.Component;
+
+//@Component
+//public class IssuseMapper {
+//    public IssueResponse toDto(Issue i) {
+//        IssueResponse idto = new IssueResponse();
+//
+//        idto.setId(i.getId());
+//        idto.setTitle(i.getTitle());
+//        idto.setPriority(i.getPriority());
+//        idto.setDescription(i.getDescription());
+//        idto.setStatus(i.getStatus());
+//        idto.setProjectName(i.getProject().getName());
+//        idto.setProjectId(i.getProject().getId());
+//        idto.setAssigneeId(i.getAssignee().getId());
+//
+//        return idto;
+//    }
+//}
+@Component
+public class IssuseMapper {
+
+    public IssueResponse toDto(Issue issue) {
+        IssueResponse dto = new IssueResponse();
+
+        dto.setId(issue.getId());
+        dto.setTitle(issue.getTitle());
+        dto.setDescription(issue.getDescription());
+        dto.setStatus(issue.getStatus());
+        dto.setPriority(issue.getPriority());
+//        dto.setCreatedAt(issue.setCreatedAt());
+
+//        // ✅ Project (safe)
+//        if (issue.getProject() != null) {
+//            dto.setProjectId(issue.getProject().getId());
+//            dto.setProjectName(issue.getProject().getName());
+//        }
+//
+//        // ✅ Assignee (nullable by design)
+//        if (issue.getAssignee() != null) {
+//            dto.setAssigneeId(issue.getAssignee().getId());
+//        } else {
+//            dto.setAssigneeId(null);
+//        }
+
+        // Project (guaranteed by fetch join)
+        dto.setProjectId(issue.getProject().getId());
+        dto.setProjectName(issue.getProject().getName());
+
+        // Assignee (nullable by design)
+        dto.setAssigneeId(
+                issue.getAssignee() != null ? issue.getAssignee().getId() : null
+        );
+
+        return dto;
+    }
+}

--- a/backend/src/main/java/com/bughive/repository/IssueRepository.java
+++ b/backend/src/main/java/com/bughive/repository/IssueRepository.java
@@ -2,9 +2,21 @@ package com.bughive.repository;
 
 import com.bughive.entity.Issue;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
     List<Issue> findByProjectIdOrderByCreatedAtDesc(Long projectId);
+
+//    @Query("""
+//        SELECT i FROM Issue i
+//        JOIN FETCH i.project p
+//        LEFT JOIN FETCH i.assignee a
+//        WHERE i.id = :id
+//    """)
+//Optional<Issue> findIssueById(@Param("id") Long id);
+Optional<Issue> findIssueById( Long id);
 }

--- a/backend/src/main/java/com/bughive/service/IssueService.java
+++ b/backend/src/main/java/com/bughive/service/IssueService.java
@@ -1,0 +1,82 @@
+package com.bughive.service;
+
+import com.bughive.dto.IssueRequest;
+import com.bughive.dto.IssueResponse;
+import com.bughive.entity.Issue;
+import com.bughive.entity.Project;
+import com.bughive.entity.User;
+import com.bughive.mapper.IssuseMapper;
+import com.bughive.repository.IssueRepository;
+
+import com.bughive.repository.ProjectRepository;
+import com.bughive.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class IssueService {
+
+    private final IssueRepository issueRepository;
+    private final IssuseMapper issuseMapper;
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+
+    public IssueResponse createIssue(IssueRequest issue){
+//        return issueRepository.save(issue);
+        // 1. Validate mandatory projectId
+        if (issue.getProjectId() == null) {
+            throw new IllegalArgumentException("projectId is required");
+        }
+        // 2. Load Project entity
+        Project project = projectRepository.findById(issue.getProjectId())
+                .orElseThrow(() -> new IllegalArgumentException("Project not found"));
+
+        // 3. Create Issue entity
+        Issue new_issue = new Issue();
+        new_issue.setTitle(issue.getTitle());
+        new_issue.setDescription(issue.getDescription());
+        new_issue.setStatus(issue.getStatus());
+        new_issue.setPriority(issue.getPriority());
+        new_issue.setProject(project);
+
+        // 4. Optional assignee
+        if (issue.getAssigneeId() != null) {
+            User assignee = userRepository.findById(issue.getAssigneeId())
+                    .orElseThrow(() -> new IllegalArgumentException("Assignee not found"));
+            new_issue.setAssignee(assignee);
+        }
+        // 5. Save and map
+        return issuseMapper.toDto(issueRepository.save(new_issue));
+    }
+
+//    public Optional<IssueResponse> getIssueById(Long id) {
+////         return issueRepository.findById(id);
+//        return Optional.ofNullable(issuseMapper.toDto(issueRepository.findById(id)));
+//    }
+        @Transactional(readOnly = true)
+      public Optional<IssueResponse> getIssueById(Long id) {
+            return issueRepository.findIssueById(id)
+                    .map(issuseMapper::toDto);
+      }
+
+
+    public @Nullable List<IssueResponse> getIssuesByProjectId(Long projectId) {
+        List<Issue> allIssues = issueRepository.findAll();
+        System.out.println(allIssues.toString());   // Debug
+        if (allIssues == null)
+            return null;
+        List<IssueResponse> issueList = allIssues.stream()
+                .filter( issue -> issue.getProject().getId().equals(projectId))
+                .map(issuseMapper::toDto)
+                .toList();
+//
+        return  issueList;
+
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 #Setting it to false avoids holding database connections longer than necessary, preventing N+1 query problems.
+#false,So that Session does not stays open till response
 spring.jpa.open-in-view=false
 
 


### PR DESCRIPTION
## Is your feature request related to a problem?
No layered APIs existed for creating and fetching Issues scoped to Projects.

## Describe the solution you'd like
- Added `IssueService` with methods:
  - `createIssue(Issue issue)` (validates `issue.project != null`)
  - `getIssuesByProject(Long projectId)`
  - `getIssueById(Long id)`
- Implemented `IssueController` following Controller → Service → Repository pattern
- Exposed REST endpoints:
  - `POST /api/issues` → create issue (returns 201)
  - `GET /api/projects/{projectId}/issues` → list issues for a project
  - `GET /api/issues/{id}` → fetch single issue or return 404
- Integrated with existing repositories to persist and retrieve data

## Describe alternatives you've considered
Direct controller-to-repository access was considered but rejected in favor of a service layer for better separation of concerns and testability.

## Additional context
- Mirrors Day 2 Project API structure
- Tested using curl/Postman:
  - Created issue for existing `projectId=1`
  - Verified listing via `/api/projects/1/issues`
  - Confirmed database row creation in PostgreSQL
- Screenshots of API responses and DB confirmation attached

Closes #16